### PR TITLE
Search bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
+*.xcode.env.local
 
 # Android/IntelliJ
 #

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View, TextInput } from 'react-native';
+import { RFValue } from "react-native-responsive-fontsize";
+
+export default class SearchBar extends React.Component {
+    constructor(props) {
+        super(props);
+      }
+    render(){ 
+        return (
+            <View style={styles.searchBarContainer}>
+                <TextInput
+                    style={styles.searchBar}
+                    placeholder="Search..."
+                    value={this.props.searchQuery}
+                    onChangeText={this.props.handleSearch}
+                />
+                <TouchableOpacity onPress={this.props.clearSearch}>
+                    <Text style={styles.clearButton}>x</Text>
+                </TouchableOpacity>
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    searchBar: {
+        width: "90%",
+        height: 32,
+        marginTop: 8,
+        padding: 0,
+        backgroundColor: 'rgb(220, 230, 232)',
+        fontSize: RFValue(16),
+        color: '#5d8da0',
+        fontFamily: 'helvetica77',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    searchBarContainer: {
+        width: '100%',
+        flexDirection: 'row',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    clearButton: {
+        fontSize: RFValue(16),
+        color: '#5d8da0',
+        fontFamily: 'helvetica77',
+    },
+});

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -5,8 +5,9 @@ import { RFValue } from "react-native-responsive-fontsize";
 export default class SearchBar extends React.Component {
     constructor(props) {
         super(props);
-      }
-    render(){ 
+    }
+    
+    render() { 
         return (
             <View style={styles.searchBarContainer}>
                 <TextInput

--- a/src/screens/Teachers.js
+++ b/src/screens/Teachers.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {StyleSheet, View, FlatList } from 'react-native';
 import TeacherCard from '../components/TeacherCard';
+import SearchBar from '../components/SearchBar';
 
 export default class TeachersScreen extends React.Component {
     static navigationOptions = {
@@ -12,9 +13,29 @@ export default class TeachersScreen extends React.Component {
         this.state = {
             isLoading: true,
             data: props.route.params.teachers ?? [],
-            user: props.route.params.user ?? {}
+            user: props.route.params.user ?? {},
+            searchQuery: '',
         }
+        this.clearSearch = this.clearSearch.bind(this);
       }
+
+    handleSearch = (text) => {
+        this.setState({searchQuery: text})
+    }
+
+    clearSearch() {
+        this.setState({searchQuery: ''})
+    }
+
+    getFilteredData() {
+        const {data, searchQuery} = this.state;
+        const sortedData = data.sort((prev, next)=>prev.fullName.localeCompare(next.fullName))
+        if (!searchQuery) {
+            return sortedData;
+        }
+
+        return sortedData.filter(item => item.fullName.toLowerCase().includes(searchQuery.toLowerCase()))
+    }
 
     _renderItem = ({item}) => {
         return (
@@ -27,11 +48,16 @@ export default class TeachersScreen extends React.Component {
     render() {
         return (
             <View style={styles.container}>
+                <SearchBar 
+                    searchQuery={this.state.searchQuery} 
+                    handleSearch={this.handleSearch} 
+                    clearSearch={this.clearSearch}
+                />
                 <FlatList 
                     style={styles.flastList}
                     contentInset={{bottom: 60}}
                     contentContainerStyle={styles.flatList}
-                    data={this.state.data.sort((prev, next)=>prev.fullName.localeCompare(next.fullName))}
+                    data={this.getFilteredData()}
                     keyExtractor={(item, index) => index.toString()}
                     extraData={this.state}
                     renderItem={(item) => this._renderItem(item)}

--- a/src/screens/Teachers.js
+++ b/src/screens/Teachers.js
@@ -20,16 +20,20 @@ export default class TeachersScreen extends React.Component {
       }
 
     handleSearch = (text) => {
-        this.setState({searchQuery: text})
+        this.setState({ searchQuery: text })
+
     }
 
     clearSearch() {
-        this.setState({searchQuery: ''})
+        this.setState({ searchQuery: '' })
+
     }
 
     getFilteredData() {
-        const {data, searchQuery} = this.state;
-        const sortedData = data.sort((prev, next)=>prev.fullName.localeCompare(next.fullName))
+        const { data, searchQuery } = this.state;
+
+        const sortedData = data.sort((prev, next) => prev.fullName.localeCompare(next.fullName))
+
         if (!searchQuery) {
             return sortedData;
         }

--- a/src/screens/WorkshopsView.js
+++ b/src/screens/WorkshopsView.js
@@ -131,13 +131,10 @@ const styles = StyleSheet.create({
         flex: 1
     },
     searchBar: {
-        width: 300,
-        height: 40,
-        margin: 30,
-        marginBottom: 10,
-        padding: 10,
-        borderWidth: 1,
-        borderRadius: 55,
+        width: "90%",
+        height: 32,
+        marginTop: 8,
+        padding: 0,
         backgroundColor: 'rgb(220, 230, 232)',
         fontSize: RFValue(16),
         color: '#5d8da0',

--- a/src/screens/WorkshopsView.js
+++ b/src/screens/WorkshopsView.js
@@ -52,7 +52,11 @@ class WorkshopsView extends React.Component {
         if (!searchQuery) {
             return selectedDateData;
         }
-        return selectedDateData.filter(item => item.title.toLowerCase().includes(searchQuery.toLowerCase()));
+        return selectedDateData.filter(item => 
+            item.title.toLowerCase().includes(searchQuery.toLowerCase()) 
+            || item.description.toLowerCase().includes(searchQuery.toLowerCase())
+            || item.type.toLowerCase().includes(searchQuery.toLowerCase())
+            || item.location.toLowerCase().includes(searchQuery.toLowerCase()));
     }
 
     _renderItem = ({item}) => {
@@ -126,9 +130,19 @@ const styles = StyleSheet.create({
     searchBar: {
         width: 300,
         height: 40,
-        margin: 12,
+        margin: 30,
+        marginBottom: 10,
         borderWidth: 1,
         padding: 10,
+        borderRadius: 55,
+        backgroundColor: 'rgb(220, 230, 232)',
+        justifyContent: 'center',
+        alignItems: 'center',
+        shadowColor: 'rgba(0,0,0, .4)', // IOS
+        shadowOffset: { height: 1, width: 1 }, // IOS
+        shadowOpacity: 1, // IOS
+        shadowRadius: 1, //IOS
+        elevation: 2, // Android
     },
 });
 

--- a/src/screens/WorkshopsView.js
+++ b/src/screens/WorkshopsView.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {StyleSheet, TextInput, View, FlatList, ActivityIndicator} from 'react-native';
 import HorizontalCalendar from 'breathe/src/components/HorizontalCalendar';
 import ScheduleCard from '../components/ScheduleCard';
+import { RFValue } from "react-native-responsive-fontsize";
 
 class WorkshopsView extends React.Component {
     static navigationOptions = {
@@ -132,17 +133,15 @@ const styles = StyleSheet.create({
         height: 40,
         margin: 30,
         marginBottom: 10,
-        borderWidth: 1,
         padding: 10,
+        borderWidth: 1,
         borderRadius: 55,
         backgroundColor: 'rgb(220, 230, 232)',
+        fontSize: RFValue(16),
+        color: '#5d8da0',
+        fontFamily: 'helvetica77',
         justifyContent: 'center',
         alignItems: 'center',
-        shadowColor: 'rgba(0,0,0, .4)', // IOS
-        shadowOffset: { height: 1, width: 1 }, // IOS
-        shadowOpacity: 1, // IOS
-        shadowRadius: 1, //IOS
-        elevation: 2, // Android
     },
 });
 

--- a/src/screens/WorkshopsView.js
+++ b/src/screens/WorkshopsView.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import {StyleSheet, TextInput, View, FlatList, ActivityIndicator, Text, TouchableOpacity} from 'react-native';
+import {StyleSheet, View, FlatList, ActivityIndicator} from 'react-native';
 import HorizontalCalendar from 'breathe/src/components/HorizontalCalendar';
 import ScheduleCard from '../components/ScheduleCard';
-import { RFValue } from "react-native-responsive-fontsize";
+import SearchBar from '../components/SearchBar';
 
 class WorkshopsView extends React.Component {
     static navigationOptions = {
@@ -16,6 +16,7 @@ class WorkshopsView extends React.Component {
         }
         this.add = this.add.bind(this);
         this.delete = this.delete.bind(this);
+        this.clearSearch = this.clearSearch.bind(this);
     }
     
     async componentDidMount () {
@@ -89,17 +90,11 @@ class WorkshopsView extends React.Component {
         else {
             return(
             <View style={styles.container}>
-                <View style={styles.searchBarContainer}>
-                    <TextInput
-                        style={styles.searchBar}
-                        placeholder="Search..."
-                        value={this.state.searchQuery}
-                        onChangeText={this.handleSearch}
-                    />
-                    <TouchableOpacity onPress={() => this.clearSearch()}>
-                        <Text style={styles.clearButton}>x</Text>
-                    </TouchableOpacity>
-                </View>
+                <SearchBar 
+                    searchQuery={this.state.searchQuery} 
+                    handleSearch={this.handleSearch} 
+                    clearSearch={this.clearSearch}
+                />
                 <HorizontalCalendar dateSelected={this.state.dateSelected} changeDate={this.changeDate}/>
                     <FlatList 
                         ref={(ref) => {this.flatlist = ref;}}
@@ -139,31 +134,6 @@ const styles = StyleSheet.create({
     flastList: {
         flex: 1
     },
-    searchBar: {
-        width: "90%",
-        height: 32,
-        marginTop: 8,
-        padding: 0,
-        backgroundColor: 'rgb(220, 230, 232)',
-        fontSize: RFValue(16),
-        color: '#5d8da0',
-        fontFamily: 'helvetica77',
-        justifyContent: 'center',
-        alignItems: 'center',
-    },
-    searchBarContainer: {
-        width: '100%',
-        flexDirection: 'row',
-        justifyContent: 'center',
-        alignItems: 'center',
-    },
-    clearButton: {
-        // position: 'absolute',
-        // right: 0,
-        fontSize: RFValue(16),
-        color: '#5d8da0',
-        fontFamily: 'helvetica77',
-    }
 });
 
 export default WorkshopsView;

--- a/src/screens/WorkshopsView.js
+++ b/src/screens/WorkshopsView.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {StyleSheet, TextInput, View, FlatList, ActivityIndicator} from 'react-native';
+import {StyleSheet, TextInput, View, FlatList, ActivityIndicator, Text, TouchableOpacity} from 'react-native';
 import HorizontalCalendar from 'breathe/src/components/HorizontalCalendar';
 import ScheduleCard from '../components/ScheduleCard';
 import { RFValue } from "react-native-responsive-fontsize";
@@ -39,6 +39,10 @@ class WorkshopsView extends React.Component {
 
     handleSearch = (text) => {
         this.setState({ searchQuery: text });
+    }
+
+    clearSearch() {
+        this.setState({ searchQuery: '' });
     }
 
     isFavorite() {}
@@ -85,13 +89,18 @@ class WorkshopsView extends React.Component {
         else {
             return(
             <View style={styles.container}>
+                <View style={styles.searchBarContainer}>
+                    <TextInput
+                        style={styles.searchBar}
+                        placeholder="Search..."
+                        value={this.state.searchQuery}
+                        onChangeText={this.handleSearch}
+                    />
+                    <TouchableOpacity onPress={() => this.clearSearch()}>
+                        <Text style={styles.clearButton}>x</Text>
+                    </TouchableOpacity>
+                </View>
                 <HorizontalCalendar dateSelected={this.state.dateSelected} changeDate={this.changeDate}/>
-                <TextInput
-                    style={styles.searchBar}
-                    placeholder="Search..."
-                    value={this.state.searchQuery}
-                    onChangeText={this.handleSearch}
-                />
                     <FlatList 
                         ref={(ref) => {this.flatlist = ref;}}
                         contentInset={{bottom: 60}}
@@ -142,6 +151,19 @@ const styles = StyleSheet.create({
         justifyContent: 'center',
         alignItems: 'center',
     },
+    searchBarContainer: {
+        width: '100%',
+        flexDirection: 'row',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    clearButton: {
+        // position: 'absolute',
+        // right: 0,
+        fontSize: RFValue(16),
+        color: '#5d8da0',
+        fontFamily: 'helvetica77',
+    }
 });
 
 export default WorkshopsView;

--- a/src/screens/WorkshopsView.js
+++ b/src/screens/WorkshopsView.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {StyleSheet, View, FlatList, ActivityIndicator} from 'react-native';
+import {StyleSheet, TextInput, View, FlatList, ActivityIndicator} from 'react-native';
 import HorizontalCalendar from 'breathe/src/components/HorizontalCalendar';
 import ScheduleCard from '../components/ScheduleCard';
 
@@ -10,6 +10,9 @@ class WorkshopsView extends React.Component {
 
     constructor(props) {
         super(props);
+        this.state = {
+            searchQuery: '',
+        }
         this.add = this.add.bind(this);
         this.delete = this.delete.bind(this);
     }
@@ -25,12 +28,16 @@ class WorkshopsView extends React.Component {
         this.setState({
             dateSelected: date,
         });
-        if (this.state.data[this.state.dateSelected] != null
-            && this.state.data[this.state.dateSelected].length > 0) {
+        if (this.getFilteredData() != null
+            && this.getFilteredData().length > 0) {
             this.flatlist.scrollToIndex({
                 index: 0
             });
         }
+    }
+
+    handleSearch = (text) => {
+        this.setState({ searchQuery: text });
     }
 
     isFavorite() {}
@@ -38,6 +45,15 @@ class WorkshopsView extends React.Component {
     async add(item) {}
 
     async delete(item) {}
+
+    getFilteredData() {
+        const { data, dateSelected, searchQuery } = this.state;
+        const selectedDateData = data[dateSelected] || [];
+        if (!searchQuery) {
+            return selectedDateData;
+        }
+        return selectedDateData.filter(item => item.title.toLowerCase().includes(searchQuery.toLowerCase()));
+    }
 
     _renderItem = ({item}) => {
         return (
@@ -63,11 +79,17 @@ class WorkshopsView extends React.Component {
             return(
             <View style={styles.container}>
                 <HorizontalCalendar dateSelected={this.state.dateSelected} changeDate={this.changeDate}/>
+                <TextInput
+                    style={styles.searchBar}
+                    placeholder="Search..."
+                    value={this.state.searchQuery}
+                    onChangeText={this.handleSearch}
+                />
                     <FlatList 
                         ref={(ref) => {this.flatlist = ref;}}
                         contentInset={{bottom: 60}}
                         contentContainerStyle={styles.flatList}
-                        data={this.state.data[this.state.dateSelected] || []}
+                        data={this.getFilteredData()}
                         keyExtractor={(item, index) => index.toString()}
                         extraData={this.state}
                         renderItem={(item) => this._renderItem(item, this.props)}
@@ -100,6 +122,13 @@ const styles = StyleSheet.create({
     },
     flastList: {
         flex: 1
+    },
+    searchBar: {
+        width: 300,
+        height: 40,
+        margin: 12,
+        borderWidth: 1,
+        padding: 10,
     },
 });
 

--- a/src/screens/WorkshopsView.js
+++ b/src/screens/WorkshopsView.js
@@ -57,7 +57,9 @@ class WorkshopsView extends React.Component {
             item.title.toLowerCase().includes(searchQuery.toLowerCase()) 
             || item.description.toLowerCase().includes(searchQuery.toLowerCase())
             || item.type.toLowerCase().includes(searchQuery.toLowerCase())
-            || item.location.toLowerCase().includes(searchQuery.toLowerCase()));
+            || item.location.toLowerCase().includes(searchQuery.toLowerCase())
+            || item.primaryInstructor.fullName.toLowerCase().includes(searchQuery.toLowerCase())
+            || item.coTeachers.toLowerCase().includes(searchQuery.toLowerCase()));
     }
 
     _renderItem = ({item}) => {


### PR DESCRIPTION
Adds a search bar to the `Schedule`, `Favorites`, and `Teachers` pages. Fixes #1.

On schedule and favorites, it searches through the workshop title, type, description, location, and primary and coteachers. On the teachers page, it searches through their full name. You can clear the search by clicking on the x.

I haven't tested it on Android.

<img width="329" alt="Screen Shot 2024-09-10 at 9 10 35 AM" src="https://github.com/user-attachments/assets/0eb78ebe-06ce-43ce-b4dd-021169a56e81">
<img width="330" alt="Screen Shot 2024-09-10 at 9 10 15 AM" src="https://github.com/user-attachments/assets/e407e3f2-c0d1-4892-b606-3566af9cb214">
